### PR TITLE
[ENH] Azure OAI client & more general way of switching between client configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ example/
 src/**/*.json
 results
 ./*.json
+client_configs/*.yaml
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ pip install git+https://github.com/tatsu-lab/alpaca_eval
 Then you can use it as follows:
 
 ```bash
-export OPENAI_API_KEY=<your_api_key>
-export OPENAI_ORGANIZATION_IDS=<your_organization_id>  # Optional; if not set, this will be your default org id.
+export OPENAI_API_KEY=<your_api_key> # for more complex configs, e.g. using Azure or switching clients see client_configs/README.md 
 alpaca_eval --model_outputs 'example/outputs.json' 
 ```
 
@@ -1334,6 +1333,7 @@ For example:
 <details>
   <summary><h2 tabindex="-1" dir="auto">Major updates</h2></summary>
 
+- 2nd January 2024: added Azure API and more general way of setting client configs. See [here](https://github.com/tatsu-lab/alpaca_eval/tree/main/client_configs/README.md)
 - 19th June 2023: add leaderboard `chatgpt_fn` that anyone can use (no waiting lists).
 - 19th June 2023: update to
   use [OpenAI's function calling](https://openai.com/blog/function-calling-and-other-api-updates).

--- a/client_configs/README.md
+++ b/client_configs/README.md
@@ -1,0 +1,74 @@
+# Client configs
+
+Client configs are json yaml that map model names to a list of configurations for instantiating a client such as the OpenAI one. 
+We use a list to allow switching client when you hit a rate limit (e.g. using a different organization ID or using Azure). 
+
+## Configuring OpenAI
+
+To use the new OpenAI configuration, create `openai_configs.yaml` in the current directory. The configuration should be a dictionary whose values are a list of configurations for OpenAI's client. We use a list to allow switching OpenAI client when you hit a rate limit (e.g. using a different organization ID or using Azure).
+
+Here's the simplest configuration if you don't need to switch between OpenAI clients:
+
+```yaml
+default:
+    - api_key: "<your OpenAI API key here>"
+      organization: "<your organization ID>"
+```
+
+
+Here's if you want to switch between organization IDs when you hit a rate limit:
+
+```yaml
+default:
+    - api_key: "<your OpenAI API key here>"
+      organization: "<your 1st organization ID>"
+
+    - api_key: "<your OpenAI API key here>"
+      organization: "<your 2nd organization ID>"
+```
+
+Note that the order does NOT matter: we will select randomly the client. This allows running multiple jobs in parallel while decreasing the chance of using the same client.  
+
+Sometimes you may need configurations that are model specific and use a different client class, for example when using Azure's client. In this case, you can do the following:
+
+
+```yaml
+default:
+    - api_key: "<your OpenAI API key here>"
+      organization: "<your 1st organization ID>"
+
+    - api_key: "<your OpenAI API key here>"
+      organization: "<your 2nd organization ID>"
+
+gpt-4-1106-preview: # only when using `model_name: gpt-4-1106-preview`
+    - "default" # this will append all the `default` configs
+    
+    - client_class: "openai.AzureOpenAI" # doesn't use the `openai.OpenAI` client class
+      # the following are passed to the `AzureOpenAI` client class
+      azure_deployment: "gpt-4-1106"
+      api_key: "<your Azure OpenAI API key here>"
+      azure_endpoint: "<your Azure OpenAI API base here>"
+      api_version: "2023-07-01-preview"
+```
+
+
+Here the configurations will be appended to `default` when using the model_name `gpt-4` in the `evaluators_configs` such as [here](https://github.com/tatsu-lab/alpaca_eval/blob/main/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/configs.yaml#L6). When hitting a rate limit we will be then switching between two OpenAI clients and one Azure, each using the same underlying model.
+
+## Fully backward compatible
+
+Prior to `alpaca_eval==0.3.7` the recommended way of setting the client was to use the environment variables `OPENAI_API_KEYS` / `OPENAI_ORGANIZATION_IDS`, which are lists of comma separated constants. **Using those will still work but will raise a warning**. Under the hood, if:
+1. `openai_configs.yaml` does not exist, and
+2. the environment variables are set
+
+then the result will essentially correspond to the following config (where keys should be expanded):
+
+```yaml
+default:
+- api_key: "<OPENAI_API_KEYS[0]>"
+  organization: "<OPENAI_ORGANIZATION_IDS[0]>"
+
+- api_key: "<OPENAI_API_KEYS[1]>"
+  organization: "<OPENAI_ORGANIZATION_IDS[1]>"
+
+...
+```

--- a/client_configs/openai_configs_example.yaml
+++ b/client_configs/openai_configs_example.yaml
@@ -1,0 +1,20 @@
+default:
+    - api_key: "<your OpenAI API key here>"
+      organization: "<your 1st organization ID>"
+
+    - api_key: "<your OpenAI API key here>"
+      organization: "<your 2nd organization ID>"
+
+gpt-4-1106-preview: # only when using `model_name: gpt-4-1106-preview`
+    - "default" # this will append all the `default` configs
+
+    - client_class: "openai.AzureOpenAI" # doesn't use the `openai.OpenAI` client class
+      # the following are passed to the `AzureOpenAI` client class
+      azure_deployment: "gpt-4-1106"
+      api_key: "<your Azure OpenAI API key here>"
+      azure_endpoint: "<your Azure OpenAI API base here>"
+      api_version: "2023-07-01-preview"
+
+a_model_on_a_local_server:
+    # don't append defaults as we are not using the openAI server => different keys and organization
+    - api_key: "<some_local_api_key>"

--- a/src/alpaca_eval/constants.py
+++ b/src/alpaca_eval/constants.py
@@ -4,14 +4,20 @@ from pathlib import Path
 
 import datasets
 
+CURRENT_DIR = Path(__file__).parent
+BASE_DIR = Path(__file__).parents[2]
+
 ### API specific ###
+OPENAI_MAX_CONCURRENCY = int(os.environ.get("OPENAI_MAX_CONCURRENCY", 5))
+OPENAI_CLIENT_CONFIG_PATH = os.environ.get("OPENAI_CLIENT_CONFIG_PATH", BASE_DIR / "client_configs/openai_configs.yaml")
+# the following is for backward compatibility, the recommended way is to use OPENAI_CLIENT_CONFIG_PATH
 OPENAI_API_KEYS = os.environ.get("OPENAI_API_KEYS", os.environ.get("OPENAI_API_KEY", None))
 if isinstance(OPENAI_API_KEYS, str):
     OPENAI_API_KEYS = OPENAI_API_KEYS.split(",")
 OPENAI_ORGANIZATION_IDS = os.environ.get("OPENAI_ORGANIZATION_IDS", None)
 if isinstance(OPENAI_ORGANIZATION_IDS, str):
     OPENAI_ORGANIZATION_IDS = OPENAI_ORGANIZATION_IDS.split(",")
-OPENAI_MAX_CONCURRENCY = int(os.environ.get("OPENAI_MAX_CONCURRENCY", 5))
+#
 
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", None)
 ANTHROPIC_MAX_CONCURRENCY = int(os.environ.get("ANTHROPIC_MAX_CONCURRENCY", 1))
@@ -24,10 +30,9 @@ DATASETS_FORCE_DOWNLOAD = os.environ.get("DATASETS_FORCE_DOWNLOAD", False)
 ########################
 
 DEFAULT_CACHE_DIR = None
-CURRENT_DIR = Path(__file__).parent
 EVALUATORS_CONFIG_DIR = CURRENT_DIR / "evaluators_configs"
 MODELS_CONFIG_DIR = CURRENT_DIR / "models_configs"
-BASE_DIR = Path(__file__).parents[2]
+
 
 MINIMAL_EVALUATORS = (
     "alpaca_eval_gpt4",

--- a/src/alpaca_eval/models_configs/Yi-34B-Chat-Verified/configs.yaml
+++ b/src/alpaca_eval/models_configs/Yi-34B-Chat-Verified/configs.yaml
@@ -2,12 +2,9 @@ Yi-34B-Chat-Verified:
   prompt_template: "Yi-34B-Chat-Verified/prompt.txt"
   fn_completions: "openai_completions"
   completions_kwargs:
-    openai_api_base: "http://api.01ww.xyz/v1"
     model_name: "yi-34b-chat"
     requires_chatml: True
     temperature: 0.3
-    openai_api_keys_from_env: "YI_API_KEY"
-    openai_organization_ids: [ Null ]
     num_procs: 1
     max_tokens: 3500
     top_p: 0.8


### PR DESCRIPTION
Todo:
- [x] Azure OpenAI client
- [x] use list of dicts instead of comma-separated string for switching between OAI clients & orgs
- [x] document
- [x] backward compatibility but raise warning

@rtaori @lxuechen FYI, I changed the recommended way of switching between OAI clients to allow more fine-grained control (e.g. the API_base) and so that we can use Azure OAI. Everything is still backward compatible though. For documentation see `client_configs/README.md`