### PR TITLE
prettify "prety_name" of internlm2

### DIFF
--- a/src/alpaca_eval/models_configs/internlm2-chat-20b-ppo/configs.yaml
+++ b/src/alpaca_eval/models_configs/internlm2-chat-20b-ppo/configs.yaml
@@ -11,5 +11,5 @@ internlm2-chat-20b-ppo:
     batch_size: 32
     eos_token_id: 92542
     remove_ending: "[UNUSED_TOKEN_145]"
-  pretty_name: "InternLM2 Chat 20B ppo"
+  pretty_name: "InternLM2 Chat 20B"
   link: "https://huggingface.co/internlm/internlm2-chat-20b"


### PR DESCRIPTION
Continuation of [PR](https://github.com/tatsu-lab/alpaca_eval/pull/207)

As per my teammates' feedback, they find the current "pretty_name" to be visually unappealing and have requested that I remove the "ppo" suffix.

Does this change apply to [leaderboard](https://tatsu-lab.github.io/alpaca_eval/)? Thanks!