### PR TITLE
Fix KeyError at line 17; annotations['preference'] -> annotation['preferences']

### DIFF
--- a/src/alpaca_eval/metrics/winrate.py
+++ b/src/alpaca_eval/metrics/winrate.py
@@ -14,7 +14,7 @@ def get_winrate(annotations: Union[pd.DataFrame, Sequence]) -> dict[str, float]:
     This assumes that the preference is encoded as 0 or 1.5 for draw, 1 for base win, 2 when the model to compare wins.
     """
     annotations = utils.convert_to_dataframe(annotations)
-    preferences = annotations["preference"]
+    preferences = annotations["preferences"]
     out = AbsoluteScoringRule().describe_head2head(preferences)
     out["discrete_win_rate"] = ZeroOneScoringRule().describe_head2head(preferences)["win_rate"]
     return out


### PR DESCRIPTION
Pull Request to fix KeyError at line 17 in `alpaca_eval/src/alpaca_eval/metrics/winrate.py`: `annotations['preference']` to `annotations['preferences']` when I use `pairwise_to_winrate` in metrics.py