### PR TITLE
[ENH] add metadata to completion: date, version,...

### DIFF
--- a/src/alpaca_eval/annotators/base.py
+++ b/src/alpaca_eval/annotators/base.py
@@ -614,6 +614,9 @@ class SingleAnnotator:
 
     completion_key : str, optional
         Key of the output of `fn_completions` to use for parsing the completions into annotations.
+
+    packages_for_which_to_show_version : Sequence[str], optional
+        List of packages for which to show the version in the metadata of the completions.
     """
 
     def __init__(
@@ -632,6 +635,7 @@ class SingleAnnotator:
         processors_to_kwargs: Optional[dict[str, dict]] = None,
         is_add_default_processors: bool = True,
         completion_key: str = "completions",
+        packages_for_which_to_show_version: Optional[Sequence[str]] = ("alpaca_eval",),
         # The following two keys are only for the documentation
         pretty_name: Optional[str] = None,
         link: Optional[str] = None,
@@ -653,6 +657,7 @@ class SingleAnnotator:
         self.batch_size = batch_size
         self.annotation_column = annotation_column
         self.completion_column = completion_column
+        self.packages_for_which_to_show_version = packages_for_which_to_show_version
 
         self.is_add_default_processors = is_add_default_processors
         self.processors = []
@@ -781,7 +786,10 @@ class SingleAnnotator:
     def _add_metadata_to_completions_(self, completions: dict[str, Any]):
         """Add metadata to the completions."""
         completions[f"{self.annotation_column}_date"] = datetime.now().isoformat()
-        completions[f"{self.annotation_column}_version"] = alpaca_eval.__version__
+        if self.packages_for_which_to_show_version is not None:
+            completions[f"{self.annotation_column}_version"] = " ".join(
+                [f"{p}=={utils.get_package_version(p)}" for p in self.packages_for_which_to_show_version]
+            )
 
     def _preprocess(self, df_to_annotate: pd.DataFrame) -> pd.DataFrame:
         """Preprocess the examples before annotating. In particular, takes care of all the randomization."""

--- a/src/alpaca_eval/annotators/base.py
+++ b/src/alpaca_eval/annotators/base.py
@@ -107,6 +107,7 @@ class BaseAnnotator(abc.ABC):
         is_raise_if_missing_primary_keys: bool = True,
         annotation_type: Optional[Type] = None,
         is_reapply_parsing: bool = False,
+        **single_annotator_kwargs,
     ):
         logging.info(f"Creating the annotator from `{annotators_config}`.")
         base_dir = base_dir or self.DEFAULT_BASE_DIR
@@ -130,7 +131,7 @@ class BaseAnnotator(abc.ABC):
             if self.annotators_config.exists():
                 break
 
-        self.annotators = self._initialize_annotators()
+        self.annotators = self._initialize_annotators(**single_annotator_kwargs)
         self.df_annotations = None
 
         other_output_keys_to_keep = [c.format(annotation_key=self.annotation_key) for c in other_output_keys_to_keep]
@@ -241,7 +242,7 @@ class BaseAnnotator(abc.ABC):
 
         return annotators_config
 
-    def _initialize_annotators(self) -> dict[str, "SingleAnnotator"]:
+    def _initialize_annotators(self, **kwargs) -> dict[str, "SingleAnnotator"]:
         """Load all the configs and prompts if necessary."""
         annotators_config = utils.load_configs(self.annotators_config)
         try:
@@ -257,6 +258,7 @@ class BaseAnnotator(abc.ABC):
                 annotation_column=self.annotation_key,
                 completion_column=self.completion_key,
                 **annotator_config,
+                **kwargs,
             )
             for name, annotator_config in annotators_config.items()
         }

--- a/src/alpaca_eval/annotators/base.py
+++ b/src/alpaca_eval/annotators/base.py
@@ -2,12 +2,15 @@ import abc
 import json
 import logging
 import os
+from datetime import datetime
 from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Optional, Sequence, Type, Union
 
 import numpy as np
 import pandas as pd
+
+import alpaca_eval
 
 from .. import completion_parsers, constants, processors, types, utils
 from ..decoders import get_fn_completions
@@ -50,10 +53,12 @@ class BaseAnnotator(abc.ABC):
         Keys use to distinguish the example.
 
     other_output_keys_to_keep : sequence of str, optional
-        Other output columns to store besides the annotations.
+        Other output columns to store besides the annotations. You can use `{annotation_key}` to refer to the name
+        of the annotation column.
 
     other_input_keys_to_keep : sequence of str, optional
-        Other columns to keep from the input dataframe besides the primary keys.
+        Other columns to keep from the input dataframe besides the primary keys. You can use `{annotation_key}` to refer
+        to the name of the annotation column.
 
     is_store_missing_annotations : bool, optional
         Whether to store missing annotations. If True it avoids trying to reannotate examples that have errors.
@@ -90,9 +95,11 @@ class BaseAnnotator(abc.ABC):
         seed: Optional[int] = 0,
         is_avoid_reannotations: bool = True,
         other_output_keys_to_keep: Sequence[str] = (
-            "price_per_example",
-            "time_per_example",
-            "raw_completion",
+            "{annotation_key}_price_per_example",
+            "{annotation_key}_time_per_example",
+            "{annotation_key}_version",
+            "{annotation_key}_date",
+            "{annotation_key}_raw_completion",
         ),
         other_input_keys_to_keep: Sequence[str] = (),
         is_store_missing_annotations: bool = True,
@@ -126,6 +133,8 @@ class BaseAnnotator(abc.ABC):
         self.annotators = self._initialize_annotators()
         self.df_annotations = None
 
+        other_output_keys_to_keep = [c.format(annotation_key=self.annotation_key) for c in other_output_keys_to_keep]
+        other_input_keys_to_keep = [c.format(annotation_key=self.annotation_key) for c in other_input_keys_to_keep]
         self.other_input_keys_to_keep = self._get_other_input_keys_to_keep(other_input_keys_to_keep)
         self.other_output_keys_to_keep = self._get_other_output_keys_to_keep(other_output_keys_to_keep)
         self.other_keys_to_keep = self.other_output_keys_to_keep + self.other_input_keys_to_keep
@@ -147,6 +156,11 @@ class BaseAnnotator(abc.ABC):
     def annotation_key(self) -> str:
         """How to refer to the annotations, this will be the key for annotations in the output."""
         return "annotation"
+
+    @property
+    def completion_key(self) -> str:
+        """How to refer to the raw completions, this will be the key for raw completions in the output."""
+        return f"{self.annotation_key}_raw_completion"
 
     @property
     def random_seed_keys(self) -> list[str]:
@@ -241,6 +255,7 @@ class BaseAnnotator(abc.ABC):
                 seed=self.seed,
                 base_dir=base_dir,
                 annotation_column=self.annotation_key,
+                completion_column=self.completion_key,
                 **annotator_config,
             )
             for name, annotator_config in annotators_config.items()
@@ -311,8 +326,8 @@ class BaseAnnotator(abc.ABC):
                 ]
                 # if df_to_annotate "raw_completion" is a dict, put it back to a json string so that you can reparse it
                 # TODO: this is for backward compatibility, remove in the future
-                if "raw_completion" in df_to_annotate.columns:
-                    df_to_annotate["raw_completion"] = df_to_annotate["raw_completion"].apply(
+                if self.completion_key in df_to_annotate.columns:
+                    df_to_annotate[self.completion_key] = df_to_annotate[self.completion_key].apply(
                         lambda x: json.dumps(x) if isinstance(x, dict) else x
                     )
 
@@ -583,11 +598,11 @@ class SingleAnnotator:
     annotation_column : str, optional
         Name of the annotation column in the output dataframe.
 
-    is_store_raw_completions : bool, optional
-        Whether to store raw completions at `"raw_completion"` column in the output dataframe. Note that raw_completion
-        will not be modified by the postprocessors. E.g. if we switch the columns output_1 and output_2 in the prompt
-        then the raw completion will show the switched order, which makes interpretation harder. This should
-        nevertheless not be an issue when using reapply_parsing because of seeding.
+    completion_column : str, optional
+        Name of the raw completion column in the output dataframe. If None will not store the raw completions. Note that
+        raw_completion will not be modified by the postprocessors. E.g. if we switch the columns output_1 and output_2
+        in the prompt then the raw completion will show the switched order, which makes interpretation harder. This
+        should nevertheless not be an issue when using reapply_parsing because of seeding.
 
     processors_to_kwargs : Sequence[dict(str, dict)], optional
         A dictionary of BaseProcessor objects to apply for preprocessing the  dataframe before making the prompts and
@@ -613,7 +628,7 @@ class SingleAnnotator:
         batch_size: int = 1,
         base_dir: types.AnyPath = constants.EVALUATORS_CONFIG_DIR,
         annotation_column: str = "annotation",
-        is_store_raw_completions: bool = True,
+        completion_column: Optional[str] = "raw_completion",
         processors_to_kwargs: Optional[dict[str, dict]] = None,
         is_add_default_processors: bool = True,
         completion_key: str = "completions",
@@ -637,7 +652,7 @@ class SingleAnnotator:
         self.is_shuffle = is_shuffle
         self.batch_size = batch_size
         self.annotation_column = annotation_column
-        self.completion_column = "raw_completion" if is_store_raw_completions else None
+        self.completion_column = completion_column
 
         self.is_add_default_processors = is_add_default_processors
         self.processors = []
@@ -690,6 +705,7 @@ class SingleAnnotator:
             # prompts and completions here will not be the same length as the dataframe due to batching
             prompts, df_to_annotate = self._make_prompts(df_to_annotate)
             completions = self.fn_completions(prompts=prompts, **self.completions_kwargs, **decoding_kwargs)
+            self._add_metadata_to_completions_(completions)
 
             for k, v in completions.items():
                 if k != "completions":
@@ -761,6 +777,11 @@ class SingleAnnotator:
         if prompt_template is None:
             prompt_template = self.prompt_template
         return utils.make_prompts(df=df_to_annotate, template=prompt_template, batch_size=self.batch_size)
+
+    def _add_metadata_to_completions_(self, completions: dict[str, Any]):
+        """Add metadata to the completions."""
+        completions[f"{self.annotation_column}_date"] = datetime.now().isoformat()
+        completions[f"{self.annotation_column}_version"] = alpaca_eval.__version__
 
     def _preprocess(self, df_to_annotate: pd.DataFrame) -> pd.DataFrame:
         """Preprocess the examples before annotating. In particular, takes care of all the randomization."""

--- a/src/alpaca_eval/decoders/__init__.py
+++ b/src/alpaca_eval/decoders/__init__.py
@@ -102,5 +102,15 @@ def get_fn_completions(name: Union[str, Callable]) -> Callable:
             logging.exception(f"You need {packages} to use bedrock_anthropic. Error:")
             raise e
 
+    elif name == "cache_completions":
+        from .cache import cache_completions
+
+        return cache_completions
+
+    elif name == "test_completions":
+        from .test import test_completions
+
+        return test_completions
+
     else:
         raise ValueError(f"Unknown decoder: {name}")

--- a/src/alpaca_eval/decoders/cache.py
+++ b/src/alpaca_eval/decoders/cache.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+from typing import Sequence
+
+from alpaca_eval.decoders import get_fn_completions
+from alpaca_eval.types import AnyPath
+
+__all__ = ["cache_completions"]
+
+
+def cache_completions(prompts: Sequence[str], fn_completions: str, cache_path: AnyPath, **completions_kwargs):
+    """Simple wrapper around a completion function to cache the results to JSON on disk.
+    Parameters
+    ----------
+    prompts : list of str
+        Prompts to get completions for.
+
+    fn_completions : str
+        Function in `decoders.py` to use for decoding the output.
+
+    cache_path : str
+        Path to the cache file.
+
+    completions_kwargs : dict
+            kwargs for fn_completions. E.g. model_name, max_tokens, temperature, top_p, top_k, stop_seq.
+
+    """
+    assert isinstance(fn_completions, str), "fn_completions must be a string to be hashable."
+    all_args = [dict(prompt=p, fn_completions=fn_completions, completions_kwargs=completions_kwargs) for p in prompts]
+
+    cache_path = Path(cache_path)
+
+    try:
+        with open(cache_path, "r") as f:
+            cache = json.load(f)
+    except FileNotFoundError:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache = {}
+
+    outs = []
+    fn_completions = get_fn_completions(fn_completions)
+    for args in all_args:
+        hashable_args = json.dumps(args, sort_keys=True)
+        if hashable_args not in cache:
+            cache[hashable_args] = fn_completions(prompts=[args["prompt"]], **args["completions_kwargs"])
+        outs.append(cache[hashable_args])
+
+    with open(cache_path, "w") as f:
+        json.dump(cache, f)
+
+    return outs

--- a/src/alpaca_eval/decoders/test.py
+++ b/src/alpaca_eval/decoders/test.py
@@ -1,0 +1,27 @@
+import logging
+from typing import Sequence
+
+from .. import utils
+
+__all__ = ["test_completions"]
+
+
+def test_completions(
+    prompts: Sequence[str],
+    model_name="test",
+    value: str = "{'name': 'test'}",
+    **decoding_kwargs,
+) -> dict[str, list]:
+    """Completion function for testing purposes. Returns the same value for all prompts."""
+
+    n_examples = len(prompts)
+
+    kwargs = dict(model_name=model_name, **decoding_kwargs)
+    logging.info(f"Kwargs to completion: {kwargs}")
+    with utils.Timer() as t:
+        responses = [value for _ in prompts]
+    avg_time = [t.duration / n_examples] * len(responses)
+    price_per_example = [0] * len(responses)
+    return dict(
+        completions=responses, price_per_example=price_per_example, time_per_example=avg_time, completions_all=responses
+    )

--- a/src/alpaca_eval/main.py
+++ b/src/alpaca_eval/main.py
@@ -322,7 +322,7 @@ def evaluate_from_model(
         if len(curr_outputs) > 0:
             prompts, _ = utils.make_prompts(
                 curr_outputs,
-                template=utils.read_or_return(base_dir / configs["prompt_template"]),
+                template=utils.read_or_return(configs["prompt_template"], relative_to=base_dir),
             )
             fn_completions = decoders.get_fn_completions(configs["fn_completions"])
             completions = fn_completions(prompts=prompts, **configs["completions_kwargs"])["completions"]

--- a/src/alpaca_eval/utils.py
+++ b/src/alpaca_eval/utils.py
@@ -648,3 +648,8 @@ def _string_to_dict(to_convert):
     {'name': 'user', 'university': 'stanford'}
     """
     return {s.split("=", 1)[0]: s.split("=", 1)[1] for s in to_convert.split(" ") if len(s) > 0}
+
+
+def get_package_version(package_name: str) -> str:
+    """Get the version of a package."""
+    return pkg_resources.get_distribution(package_name).version

--- a/src/alpaca_eval/utils.py
+++ b/src/alpaca_eval/utils.py
@@ -29,13 +29,18 @@ AnyData = Union[Sequence[dict[str, Any]], pd.DataFrame, datasets.Dataset]
 DUMMY_EXAMPLE = dict(instruction="1+1=", output_1="2", input="", output_2="3")
 
 
-def read_or_return(to_read: Union[AnyPath, str], **kwargs):
+def read_or_return(to_read: Union[AnyPath, str], relative_to: Optional[str] = None, **kwargs):
     """Read a file or return the input if it is already a string."""
+    is_str_input = isinstance(to_read, str)
+
+    if relative_to is not None:
+        to_read = Path(relative_to) / to_read
+
     try:
         with open(Path(to_read), **kwargs) as f:
             out = f.read()
     except FileNotFoundError as e:
-        if Path(to_read).is_absolute():
+        if is_str_input and Path(to_read).is_absolute():
             # The path is not absolute, so it's not just a string
             raise e
 
@@ -235,7 +240,7 @@ def check_imports(modules: Sequence[str], to_use: str = "this fnction"):
 
 
 def check_pkg_atleast_version(package, atleast_version):
-    curr_version = pkg_resources.get_distribution(package).version
+    curr_version = get_package_version(package)
     return pkg_resources.parse_version(curr_version) > pkg_resources.parse_version(atleast_version)
 
 
@@ -310,33 +315,39 @@ class DisableLogger:
         logging.disable(logging.NOTSET)
 
 
-def contains_list(text):
-    """Check if the text contains a list / bullet points...."""
+def contains_list(text: str, is_return_count: bool = False) -> Union[bool, int]:
+    """
+    Check if the text contains list items or count the number of list items.
 
-    # Bullet points or '*' list items
-    bullet_point_pattern = r"(\s*•\s*|\s*\*\s*)(\w+)"
+    Parameters:
+    - text (str): The input text to check.
+    - is_return_count (bool): If True, return the count of list items. If False, return a boolean indicating presence of list items.
 
-    # Numbered lists with '.' or ')'
-    number_list_pattern = r"(\s*\d+\.|\s*\d+\))\s*(\w+)"
+    Returns:
+    - int or bool: Returns the count of list items if is_return_count is True, otherwise returns True/False.
+    """
 
-    # Alphabetic lists with '.' or ')'
-    alpha_list_pattern = r"(\s*[a-zA-Z]\.|\s*[a-zA-Z]\))\s*(\w+)"
-
-    # List items starting with a dash '-'
-    dash_list_pattern = r"(\s*-\s*)(\w+)"
+    # Patterns to match different types of list items
+    bullet_point_pattern = r"(?m)^\s*[\*\•\-]\s*[^\w]*\w+"  # Matches bullets like "* item" or "• item" or "- item"
+    number_list_pattern = r"(?m)^\s*\d+[\.\)]\s*[^\w]*\w+"  # Matches numbered lists like "1. item" or "1) item"
+    alpha_list_pattern = r"(?m)^\s*[a-zA-Z][\.\)]\s+[^\w]*\w+"  # Matches lettered lists like "a. item" or "A) item"
 
     patterns = [
         bullet_point_pattern,
         number_list_pattern,
         alpha_list_pattern,
-        dash_list_pattern,
     ]
 
-    for pattern in patterns:
-        if re.search(pattern, text):
-            return True
+    count = 0
 
-    return False
+    for pattern in patterns:
+        matches = re.findall(pattern, text)
+        count += len(matches)
+
+    if is_return_count:
+        return count
+    else:
+        return count > 0
 
 
 def prioritize_elements(lst: list, elements: Sequence) -> list:
@@ -653,3 +664,8 @@ def _string_to_dict(to_convert):
 def get_package_version(package_name: str) -> str:
     """Get the version of a package."""
     return pkg_resources.get_distribution(package_name).version
+
+
+def get_multi_package_version(package_names: Sequence[str]) -> str:
+    """Get the version of multiple packages."""
+    return " ".join([f"{p}=={get_package_version(p)}" for p in package_names])

--- a/tests/test_pairwise_evaluator.py
+++ b/tests/test_pairwise_evaluator.py
@@ -74,6 +74,8 @@ def test_single_annotator(single_annotator, df_to_annotate):
         "output_2",
         "preference",
         "completions",
+        "preference_date",
+        "preference_version",
     }
     # check that you also save the completions.
     assert df_annotated["completions"].tolist() == parsable_completions

--- a/tests/test_pairwise_evaluator.py
+++ b/tests/test_pairwise_evaluator.py
@@ -51,7 +51,7 @@ def single_annotator():
         completion_parser_kwargs=dict(outputs_to_match={1: r"(?:^|\n) ?Output \(a\)", 2: "(?:^|\n) ?Output \(b\)"}),
         is_randomize_output_order=False,
         is_shuffle=False,
-        is_store_raw_completions=False,
+        completion_column=None,
     )
 
 


### PR DESCRIPTION
Make the following changes to improve usability of alapca_eval in dow\nstream codebases (including rubric_eval)

Done:
- [x] add completion date
- [x] add version date
- [x] add cache and test completion function
- [x] better contains_list
- [x] add "{annotation_column}_" to completions