### PR TITLE
Don't set root logger to INFO to avoid turning on all packages' logs

### DIFF
--- a/src/alpaca_eval/annotators/base.py
+++ b/src/alpaca_eval/annotators/base.py
@@ -16,7 +16,6 @@ from .. import completion_parsers, constants, processors, types, utils
 from ..decoders import get_fn_completions
 
 CURRENT_DIR = Path(__file__).parent
-logging.getLogger().setLevel(logging.INFO)
 
 __all__ = ["BaseAnnotator", "BaseAnnotatorJSON", "SingleAnnotator"]
 


### PR DESCRIPTION
A small request! the line of code below sets the root logger's level to INFO. This causes INFO messages to be printed for every package that isn't manually set otherwise. This can be really noisy; `httpx` will for instance print a message for each request.

Changing this here would mean INFO messages from alpaca are not printed by default; that's also Python's default.

If that's undesirable, and you're open to it, I can open a PR that routes all logging through an "alpaca_eval" logger that can be set to INFO individually.