### PR TITLE
Update Ubuntu image version for automated runners

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     strategy:
       matrix:
         python-version: [ "3.10" ]

--- a/.github/workflows/test_update_leaderboard.yml
+++ b/.github/workflows/test_update_leaderboard.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   format_leaderboard:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     strategy:
       matrix:
         python-version: [ "3.10" ]

--- a/.github/workflows/update_leaderboard.yml
+++ b/.github/workflows/update_leaderboard.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   format_leaderboard:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
According to https://github.com/actions/runner-images/issues/11101, the currently used version `ubuntu-20.04` will no longer be supported from 15-05-2025. This PR changes the Ubuntu version of the runners to `ubuntu-24.04` in accordance with the github actions recommendation.