### PR TITLE
Fix make_leaderboard: pass correct kwarg to print_leaderboard

### DIFF
--- a/src/alpaca_eval/main.py
+++ b/src/alpaca_eval/main.py
@@ -462,7 +462,9 @@ def make_leaderboard(
         return df_leaderboard, all_annotations
     else:
         utils.print_leaderboard(
-            df_leaderboard, leaderboard_mode=None, cols_to_print=["win_rate", "standard_error", "n_total"]
+            df_leaderboard,
+            leaderboard_mode_or_models=None,
+            cols_to_print=["win_rate", "standard_error", "n_total"]
         )
 
 


### PR DESCRIPTION
This PR fixes a TypeError raised by `alpaca_eval make_leaderboard` when `--is_return_instead_of_print` is set to `false`. Specifically, `main.make_leaderboard` passes an outdated keyword argument (`leaderboard_mode`) to `utils.print_leaderboard()`, but the current `print_leaderboard()` signature expects `leaderboard_mode_or_models`.

close #460 
